### PR TITLE
[develop] Add application message cache support

### DIFF
--- a/product/pom.xml
+++ b/product/pom.xml
@@ -130,6 +130,12 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.modelmapper</groupId>
+            <artifactId>modelmapper</artifactId>
+            <version>2.3.8</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/ProductApplication.java
+++ b/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/ProductApplication.java
@@ -3,6 +3,9 @@ package com.bestfriends.goodsdeliveryapi.product;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * Application entry point.
+ */
 @SpringBootApplication
 public class ProductApplication {
 

--- a/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/ProductApplication.java
+++ b/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/ProductApplication.java
@@ -1,4 +1,4 @@
-package com.bestfriends.goodsdeliveryapi.product.product;
+package com.bestfriends.goodsdeliveryapi.product;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/cache/ApplicationMessageCash.java
+++ b/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/cache/ApplicationMessageCash.java
@@ -1,0 +1,9 @@
+package com.bestfriends.goodsdeliveryapi.product.cache;
+
+import com.bestfriends.goodsdeliveryapi.product.cache.entities.CachedApplicationMessage;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApplicationMessageCash extends CrudRepository<CachedApplicationMessage, Long> {
+}

--- a/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/cache/ApplicationMessageCash.java
+++ b/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/cache/ApplicationMessageCash.java
@@ -4,6 +4,9 @@ import com.bestfriends.goodsdeliveryapi.product.cache.entities.CachedApplication
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+/**
+ * Repository used for fetching {@link CachedApplicationMessage} from cache.
+ */
 @Repository
 public interface ApplicationMessageCash extends CrudRepository<CachedApplicationMessage, Long> {
 }

--- a/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/cache/entities/CachedApplicationMessage.java
+++ b/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/cache/entities/CachedApplicationMessage.java
@@ -1,0 +1,16 @@
+package com.bestfriends.goodsdeliveryapi.product.cache.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.RedisHash;
+
+@RedisHash("cachedApplicationMessage")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CachedApplicationMessage {
+    private Long id;
+
+    private String message;
+}

--- a/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/cache/entities/CachedApplicationMessage.java
+++ b/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/cache/entities/CachedApplicationMessage.java
@@ -5,6 +5,10 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.redis.core.RedisHash;
 
+/**
+ * Instances of this class can be saved to cache.
+ * {@link RedisHash} annotation defined key which will be used by cache. It should be unique.
+ */
 @RedisHash("cachedApplicationMessage")
 @Data
 @AllArgsConstructor

--- a/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/config/ApplicationMessageLoader.java
+++ b/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/config/ApplicationMessageLoader.java
@@ -11,6 +11,9 @@ import javax.annotation.PostConstruct;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Class used for loading application message from db into cache on application startup.
+ */
 @Configuration
 public class ApplicationMessageLoader {
     private final ApplicationMessageCash cash;
@@ -26,6 +29,10 @@ public class ApplicationMessageLoader {
         this.modelMapper = modelMapper;
     }
 
+    /**
+     * This method is executed on application startup and loads application message from db into cache.
+     * Before loading method removes all existing messages from cache which id's matches with id's from db.
+     */
     @PostConstruct
     public void loadMessagesIntoCache() {
         List<CachedApplicationMessage> applicationMessages =

--- a/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/config/ApplicationMessageLoader.java
+++ b/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/config/ApplicationMessageLoader.java
@@ -1,0 +1,39 @@
+package com.bestfriends.goodsdeliveryapi.product.config;
+
+import com.bestfriends.goodsdeliveryapi.product.cache.ApplicationMessageCash;
+import com.bestfriends.goodsdeliveryapi.product.cache.entities.CachedApplicationMessage;
+import com.bestfriends.goodsdeliveryapi.product.repositories.ApplicationMessageRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Configuration
+public class ApplicationMessageLoader {
+    private final ApplicationMessageCash cash;
+    private final ApplicationMessageRepository applicationMessageRepository;
+    private final ModelMapper modelMapper;
+
+    @Autowired
+    public ApplicationMessageLoader(ApplicationMessageCash cash,
+                                    ApplicationMessageRepository applicationMessageRepository,
+                                    ModelMapper modelMapper) {
+        this.cash = cash;
+        this.applicationMessageRepository = applicationMessageRepository;
+        this.modelMapper = modelMapper;
+    }
+
+    @PostConstruct
+    public void loadMessagesIntoCache() {
+        List<CachedApplicationMessage> applicationMessages =
+                applicationMessageRepository.findAll().stream()
+                        .map(m -> modelMapper.map(m, CachedApplicationMessage.class))
+                        .collect(Collectors.toList());
+
+        cash.deleteAll(applicationMessages);
+        cash.saveAll(applicationMessages);
+    }
+}

--- a/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/config/ModelMapperConfig.java
+++ b/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/config/ModelMapperConfig.java
@@ -1,0 +1,13 @@
+package com.bestfriends.goodsdeliveryapi.product.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ModelMapperConfig {
+    @Bean
+    public ModelMapper modelMapper() {
+        return new ModelMapper();
+    }
+}

--- a/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/config/ModelMapperConfig.java
+++ b/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/config/ModelMapperConfig.java
@@ -4,6 +4,10 @@ import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * {@link ModelMapper} configuration.
+ * {@link ModelMapper} used for mapping one class to another.
+ */
 @Configuration
 public class ModelMapperConfig {
     @Bean

--- a/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/constants/ApplicationMessages.java
+++ b/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/constants/ApplicationMessages.java
@@ -1,0 +1,10 @@
+package com.bestfriends.goodsdeliveryapi.product.constants;
+
+import com.bestfriends.goodsdeliveryapi.product.constants.messages.ErrorMessages;
+
+/**
+ * Child interface of other interfaces that contain application messages.
+ * Can be used to access constants from parent interfaces.
+ */
+public interface ApplicationMessages extends ErrorMessages {
+}

--- a/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/constants/messages/ErrorMessages.java
+++ b/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/constants/messages/ErrorMessages.java
@@ -1,0 +1,7 @@
+package com.bestfriends.goodsdeliveryapi.product.constants.messages;
+
+/**
+ * Interface that contain error message ids.
+ */
+public interface ErrorMessages {
+}

--- a/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/model/ApplicationMessage.java
+++ b/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/model/ApplicationMessage.java
@@ -7,6 +7,10 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+/**
+ * Application message entity.
+ * Used for exception messages, user messages etc.
+ */
 @Entity
 @Table(name = "setup_application_messages")
 @Data

--- a/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/model/ApplicationMessage.java
+++ b/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/model/ApplicationMessage.java
@@ -1,0 +1,20 @@
+package com.bestfriends.goodsdeliveryapi.product.model;
+
+import lombok.Data;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "setup_application_messages")
+@Data
+public class ApplicationMessage {
+    @Id
+    @Column(name = "application_message_id")
+    private Long id;
+
+    @Column(name = "application_message", nullable = false, unique = true)
+    private String message;
+}

--- a/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/repositories/ApplicationMessageRepository.java
+++ b/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/repositories/ApplicationMessageRepository.java
@@ -1,0 +1,9 @@
+package com.bestfriends.goodsdeliveryapi.product.repositories;
+
+import com.bestfriends.goodsdeliveryapi.product.model.ApplicationMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApplicationMessageRepository extends JpaRepository<ApplicationMessage, Long> {
+}

--- a/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/repositories/ApplicationMessageRepository.java
+++ b/product/src/main/java/com/bestfriends/goodsdeliveryapi/product/repositories/ApplicationMessageRepository.java
@@ -4,6 +4,9 @@ import com.bestfriends.goodsdeliveryapi.product.model.ApplicationMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+/**
+ * Repository used for working with {@link ApplicationMessage}.
+ */
 @Repository
 public interface ApplicationMessageRepository extends JpaRepository<ApplicationMessage, Long> {
 }

--- a/product/src/main/resources/application-develop.properties
+++ b/product/src/main/resources/application-develop.properties
@@ -10,7 +10,9 @@ spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
 
 # liquibase
-spring.liquibase.enabled=false
+spring.liquibase.enabled=true
+spring.liquibase.contexts=develop
+liquibase.trimCsvWhitespace=false
 
 # Spring Security
 security.basic.enabled=false

--- a/product/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/product/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,3 @@
+databaseChangeLog:
+  - include:
+      file: /db/changelog/v-1.0/db.changelog-master.yaml

--- a/product/src/main/resources/db/changelog/v-1.0/db.changelog-master.yaml
+++ b/product/src/main/resources/db/changelog/v-1.0/db.changelog-master.yaml
@@ -1,0 +1,5 @@
+databaseChangeLog:
+  - include:
+      file: /db/changelog/v-1.0/ddl/db.changelog-2020-07-16--add-setup-application-messages-table.yaml
+  - include:
+      file: /db/changelog/v-1.0/setupData/db.changelog-2020-07-18--add-setup-application-messages-setup-data.yaml

--- a/product/src/main/resources/db/changelog/v-1.0/ddl/db.changelog-2020-07-16--add-setup-application-messages-table.yaml
+++ b/product/src/main/resources/db/changelog/v-1.0/ddl/db.changelog-2020-07-16--add-setup-application-messages-table.yaml
@@ -1,0 +1,31 @@
+databaseChangeLog:
+  - changeSet:
+      id: db.changelog-2020-07-16--add-setup-application-messages-table-1
+      author: 0lezhka
+      context: production, develop
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  name: application_message_id
+                  type: bigint
+              - column:
+                  name: application_message
+                  type: varchar(500)
+            remarks: This table contains application messages (error messages, user messages etc.).
+            tableName: setup_application_messages
+  - changeSet:
+      id: db.changelog-2020-07-16--add-setup-application-messages-table-2
+      author: 0lezhka
+      context: production, develop
+      changes:
+        - addPrimaryKey:
+            columnNames: application_message_id
+            constraintName: application_message_id_pk
+            tableName: setup_application_messages
+            validate: true
+        - addUniqueConstraint:
+            columnNames: application_message
+            constraintName: application_message_unique_constraint
+            tableName: setup_application_messages
+            validate: true

--- a/product/src/main/resources/db/changelog/v-1.0/setupData/db.changelog-2020-07-18--add-setup-application-messages-setup-data.yaml
+++ b/product/src/main/resources/db/changelog/v-1.0/setupData/db.changelog-2020-07-18--add-setup-application-messages-setup-data.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: db.changelog-2020-07-16--add-setup-product-source-sites-setup-data-1
+      author: 0lezhka
+      context: production, develop
+      changes:
+        - loadData:
+            columns:
+              - column:
+                  name: application_message_id
+                  type: numeric
+              - column:
+                  name: application_message
+                  type: string
+            commentLineStartsWith: "#"
+            encoding: UTF-8
+            file: /db/changelog/v-1.0/setupDataFiles/setup_application_messages.csv
+            quotchar:  ''''
+            relativeToChangelogFile: false
+            separator: ';'
+            tableName: setup_application_messages
+            usePreparedStatements: true

--- a/product/src/main/resources/db/changelog/v-1.0/setupDataFiles/setup_application_messages.csv
+++ b/product/src/main/resources/db/changelog/v-1.0/setupDataFiles/setup_application_messages.csv
@@ -1,0 +1,1 @@
+application_message_id;application_message


### PR DESCRIPTION
Add classes and migrations for application message cache.

Application message cache is Redis cache where messages that are used in application stores. 
This was added instead off saving messages in simple java class.
All messages are stored in db, but on application startup messages are loading in Redis cache and can be access via `ApplicationMessageCash ` class as a simple Spring Repository.
If you want add new application message you should add new migration or add record in existing one with needed message, add constant in `ErrorMessages` interface with id of new message and use that constant instead hard coded id. 